### PR TITLE
travis: set GOVERSION environment properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 env:
-  - GOVERSION = 1.8
-  - GOVERSION = 1.9
+  - GOVERSION=1.8
+  - GOVERSION=1.9
 
 install: true
 


### PR DESCRIPTION
Closes #4.

GOVERSION wasn't being set in the environment so travis was testing Go 1.9 twice.