### PR TITLE
Switch to dcrd's crypto/blake256 module

### DIFF
--- a/base58check.go
+++ b/base58check.go
@@ -8,7 +8,7 @@ package base58
 import (
 	"errors"
 
-	"github.com/dchest/blake256"
+	"github.com/decred/dcrd/crypto/blake256"
 )
 
 // ErrChecksum indicates that the checksum of a check-encoded string does not verify against

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/base58
 
-require github.com/dchest/blake256 v1.0.0
+require github.com/decred/dcrd/crypto/blake256 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=


### PR DESCRIPTION
This removes a duplicate package under a different import path from
many applications, including dcrd and dcrwallet.