### PR TITLE
Optimize Decode and CheckDecode

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,35 +15,59 @@ var bigRadix = big.NewInt(58)
 var bigZero = big.NewInt(0)
 
 // Decode decodes a modified base58 string to a byte slice.
-func Decode(b string) []byte {
-	answer := big.NewInt(0)
-	j := big.NewInt(1)
+func Decode(input string) []byte {
+	if len(input) == 0 {
+		return []byte("")
+	}
 
-	scratch := new(big.Int)
-	for i := len(b) - 1; i >= 0; i-- {
-		tmp := b58[b[i]]
-		if tmp == 255 {
+	// The max possible output size is when a base58 encoding consists of
+	// nothing but the alphabet character at index 0 which would result in the
+	// same number of bytes as the number of input chars.
+	output := make([]byte, len(input))
+
+	// Encode to base256 in reverse order to avoid extra calculations to
+	// determine the final output size in favor of just keeping track while
+	// iterating.
+	var index int
+	for _, r := range input {
+		// Invalid base58 character.
+		val := uint32(b58[r])
+		if val == 255 {
 			return []byte("")
 		}
-		scratch.SetInt64(int64(tmp))
-		scratch.Mul(j, scratch)
-		answer.Add(answer, scratch)
-		j.Mul(j, bigRadix)
-	}
 
-	tmpval := answer.Bytes()
-
-	var numZeros int
-	for numZeros = 0; numZeros < len(b); numZeros++ {
-		if b[numZeros] != alphabetIdx0 {
-			break
+		// Multiply each byte in the output by 58 and encode to base256 while
+		// propagating the carry.
+		for i, b := range output[:index] {
+			val += uint32(b) * 58
+			output[i] = byte(val)
+			val >>= 8
+		}
+		for ; val > 0; val >>= 8 {
+			output[index] = byte(val)
+			index++
 		}
 	}
-	flen := numZeros + len(tmpval)
-	val := make([]byte, flen)
-	copy(val[numZeros:], tmpval)
 
-	return val
+	// Account for the leading zeros in the input.  They are appended since the
+	// encoding is happening in reverse order.
+	for _, r := range input {
+		if r != alphabetIdx0 {
+			break
+		}
+
+		output[index] = 0
+		index++
+	}
+
+	// Truncate the output buffer to the actual number of decoded bytes and
+	// reverse it since it was calculated in reverse order.
+	output = output[:index:index]
+	for i := 0; i < index/2; i++ {
+		output[i], output[index-1-i] = output[index-1-i], output[i]
+	}
+
+	return output
 }
 
 // Encode encodes a byte slice to a modified base58 string.

--- a/base58_test.go
+++ b/base58_test.go
@@ -1,16 +1,14 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package base58_test
+package base58
 
 import (
 	"bytes"
 	"encoding/hex"
 	"testing"
-
-	"github.com/decred/base58"
 )
 
 var stringTests = []struct {
@@ -67,7 +65,7 @@ func TestBase58(t *testing.T) {
 	// Encode tests
 	for x, test := range stringTests {
 		tmp := []byte(test.in)
-		if res := base58.Encode(tmp); res != test.out {
+		if res := Encode(tmp); res != test.out {
 			t.Errorf("Encode test #%d failed: got: %s want: %s",
 				x, res, test.out)
 			continue
@@ -81,7 +79,7 @@ func TestBase58(t *testing.T) {
 			t.Errorf("hex.DecodeString failed failed #%d: got: %s", x, test.in)
 			continue
 		}
-		if res := base58.Decode(test.out); !bytes.Equal(res, b) {
+		if res := Decode(test.out); !bytes.Equal(res, b) {
 			t.Errorf("Decode test #%d failed: got: %q want: %q",
 				x, res, test.in)
 			continue
@@ -90,7 +88,7 @@ func TestBase58(t *testing.T) {
 
 	// Decode with invalid input
 	for x, test := range invalidStringTests {
-		if res := base58.Decode(test.in); string(res) != test.out {
+		if res := Decode(test.in); string(res) != test.out {
 			t.Errorf("Decode invalidString test #%d failed: got: %q want: %q",
 				x, res, test.out)
 			continue

--- a/base58check_test.go
+++ b/base58check_test.go
@@ -1,14 +1,12 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package base58_test
+package base58
 
 import (
 	"testing"
-
-	"github.com/decred/base58"
 )
 
 var checkEncodingStringTests = []struct {
@@ -35,12 +33,12 @@ func TestBase58Check(t *testing.T) {
 		ver[0] = test.version
 		ver[1] = 0
 		// test encoding
-		if res := base58.CheckEncode([]byte(test.in), ver); res != test.out {
+		if res := CheckEncode([]byte(test.in), ver); res != test.out {
 			t.Errorf("CheckEncode test #%d failed: got %s, want: %s", x, res, test.out)
 		}
 
 		// test decoding
-		res, version, err := base58.CheckDecode(test.out)
+		res, version, err := CheckDecode(test.out)
 		if err != nil {
 			t.Errorf("CheckDecode test #%d failed with err: %v", x, err)
 		} else if version != ver {
@@ -52,8 +50,8 @@ func TestBase58Check(t *testing.T) {
 
 	// test the two decoding failure cases
 	// case 1: checksum error
-	_, _, err := base58.CheckDecode("Axk2WA6M")
-	if err != base58.ErrChecksum {
+	_, _, err := CheckDecode("Axk2WA6M")
+	if err != ErrChecksum {
 		t.Error("Checkdecode test failed, expected ErrChecksum")
 	}
 	// case 2: invalid formats (string lengths below 5 mean the version byte and/or the checksum
@@ -61,8 +59,8 @@ func TestBase58Check(t *testing.T) {
 	testString := ""
 	for len := 0; len < 4; len++ {
 		// make a string of length `len`
-		_, _, err = base58.CheckDecode(testString)
-		if err != base58.ErrInvalidFormat {
+		_, _, err = CheckDecode(testString)
+		if err != ErrInvalidFormat {
 			t.Error("Checkdecode test failed, expected ErrInvalidFormat")
 		}
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,36 +1,34 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package base58_test
+package base58
 
 import (
 	"bytes"
 	"testing"
-
-	"github.com/decred/base58"
 )
 
 func BenchmarkBase58Encode(b *testing.B) {
-	b.StopTimer()
 	data := bytes.Repeat([]byte{0xff}, 5000)
 	b.SetBytes(int64(len(data)))
-	b.StartTimer()
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		base58.Encode(data)
+		Encode(data)
 	}
 }
 
 func BenchmarkBase58Decode(b *testing.B) {
-	b.StopTimer()
 	data := bytes.Repeat([]byte{0xff}, 5000)
-	encoded := base58.Encode(data)
+	encoded := Encode(data)
 	b.SetBytes(int64(len(encoded)))
-	b.StartTimer()
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		base58.Decode(encoded)
+		Decode(encoded)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/decred/base58
 
+go 1.11
+
 require github.com/decred/dcrd/crypto/blake256 v1.0.0


### PR DESCRIPTION
Profiling has shown the nearly 6.5% of the total allocations in dcrd are the result of `CheckDecode`, most of which are via `Decode`.

Consequently, this optimizes both to reduce memory allocations and also speed them up quite significantly for the typical usage patterns.

It consists of several commits to help ease the review.

The first commit consolidate tests into the main package to make it more consistent with the rest of the code base and to make it easier for forks since they don't have to change the import paths as much.

The second commit adds a benchmark for `CheckDecode` and updates the benchmarks for `Encode` and `Decode` to be more representative of typical usage.

The third commit updates `CheckDecode` to make use of the new zero alloc `blake256.Sum256` function to reduce the memory allocations needed to perform the decode and improves the readability of the function a bit while updating.

The final commit updates rewrites the `Decode` function to reduce the memory allocations needed to perform the decode, significantly speed it up for the typical usage patterns, and also improves the readability of the function while updating.

The following is a before and after comparison of the cumulative difference for a typical decode including the results of `CheckDecode` since it uses `Decode`.

```
benchmark               old ns/op    new ns/op    delta
---------------------------------------------------------
BenchmarkBase58Decode   4077         1036         -74.59%
BenchmarkCheckDecode    4317         1397         -67.64%

benchmark               old allocs   new allocs   delta
---------------------------------------------------------
BenchmarkBase58Decode   8            1            -87.50%
BenchmarkCheckDecode    12           2            -83.33%

benchmark               old bytes    new bytes    delta
---------------------------------------------------------
BenchmarkBase58Decode   232          48           -79.31%
BenchmarkCheckDecode    472          80           -83.05%
```