### PR TITLE
Further reduce Check{Decode,Encode} mem allocs.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -38,6 +38,7 @@ func BenchmarkBase58Decode(b *testing.B) {
 var (
 	noElideResult  []byte
 	noElideVersion [2]byte
+	noElideEncoded string
 )
 
 // BenchmarkCheckDecode benchmarks how long it takes to perform a base58 check
@@ -54,5 +55,18 @@ func BenchmarkCheckDecode(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// BenchmarkCheckEncode benchmarks how long it takes to perform a base58 check
+// encode on a typical input.
+func BenchmarkCheckEncode(b *testing.B) {
+	var input [20]byte
+	version := [2]byte{0x07, 0x3f}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		noElideEncoded = CheckEncode(input[:], version)
 	}
 }


### PR DESCRIPTION
This modifies the checksum function to return a copy the 4 checksum bytes rather than a slice to avoid escaping to the heap thereby making it zero alloc.

It also consists of a preliminary commit to add a benchmark for `CheckEncode`.

The following is a before and after comparison of a typical check encode and decode:

```
benchmark              old ns/op    new ns/op   delta
-------------------------------------------------------
BenchmarkCheckDecode   1382         1356        -1.88%
BenchmarkCheckEncode   1747         1706        -2.35%

benchmark              old allocs   new allocs  delta
-------------------------------------------------------
BenchmarkCheckDecode   2            1           -50.00%
BenchmarkCheckEncode   4            3           -25.00%

benchmark              old bytes    new bytes   delta
-------------------------------------------------------
BenchmarkCheckDecode   80           48          -40.00%
BenchmarkCheckEncode   160          128         -20.00%
```
