### PR TITLE
Cleanup tests and make them consistent.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2013-2015 The btcsuite developers
-Copyright (c) 2015-2017 The Decred developers
+Copyright (c) 2015-2019 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/base58_test.go
+++ b/base58_test.go
@@ -11,86 +11,76 @@ import (
 	"testing"
 )
 
-var stringTests = []struct {
-	in  string
-	out string
-}{
-	{"", ""},
-	{" ", "Z"},
-	{"-", "n"},
-	{"0", "q"},
-	{"1", "r"},
-	{"-1", "4SU"},
-	{"11", "4k8"},
-	{"abc", "ZiCa"},
-	{"1234598760", "3mJr7AoUXx2Wqd"},
-	{"abcdefghijklmnopqrstuvwxyz", "3yxU3u1igY8WkgtjK92fbJQCd4BZiiT1v25f"},
-	{"00000000000000000000000000000000000000000000000000000000000000", "3sN2THZeE9Eh9eYrwkvZqNstbHGvrxSAM7gXUXvyFQP8XvQLUqNCS27icwUeDT7ckHm4FUHM2mTVh1vbLmk7y"},
+// hexToBytes is a wrapper around hex.DecodeString that panics if there is an
+// error.  It MUST only be used with hard coded values in the tests.
+func hexToBytes(origHex string) []byte {
+	buf, err := hex.DecodeString(origHex)
+	if err != nil {
+		panic(err)
+	}
+	return buf
 }
 
-var invalidStringTests = []struct {
-	in  string
-	out string
-}{
-	{"0", ""},
-	{"O", ""},
-	{"I", ""},
-	{"l", ""},
-	{"3mJr0", ""},
-	{"O3yxU", ""},
-	{"3sNI", ""},
-	{"4kl8", ""},
-	{"0OIl", ""},
-	{"!@#$%^&*()-_=+~`", ""},
-}
+// TestBase58Coding ensures Decode and Encode produces the expected results for
+// both strings and raw byte data converted from hex.
+func TestBase58Coding(t *testing.T) {
+	tests := []struct {
+		decoded []byte
+		encoded string
+	}{
+		// String inputs.
+		{[]byte(""), ""},
+		{[]byte(" "), "Z"},
+		{[]byte("-"), "n"},
+		{[]byte("0"), "q"},
+		{[]byte("1"), "r"},
+		{[]byte("-1"), "4SU"},
+		{[]byte("11"), "4k8"},
+		{[]byte("abc"), "ZiCa"},
+		{[]byte("1234598760"), "3mJr7AoUXx2Wqd"},
+		{[]byte("abcdefghijklmnopqrstuvwxyz"), "3yxU3u1igY8WkgtjK92fbJQCd4BZiiT1v25f"},
+		{[]byte("00000000000000000000000000000000000000000000000000000000000000"), "3sN2THZeE9Eh9eYrwkvZqNstbHGvrxSAM7gXUXvyFQP8XvQLUqNCS27icwUeDT7ckHm4FUHM2mTVh1vbLmk7y"},
 
-var hexTests = []struct {
-	in  string
-	out string
-}{
-	{"61", "2g"},
-	{"626262", "a3gV"},
-	{"636363", "aPEr"},
-	{"73696d706c792061206c6f6e6720737472696e67", "2cFupjhnEsSn59qHXstmK2ffpLv2"},
-	{"00eb15231dfceb60925886b67d065299925915aeb172c06647", "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"},
-	{"516b6fcd0f", "ABnLTmg"},
-	{"bf4f89001e670274dd", "3SEo3LWLoPntC"},
-	{"572e4794", "3EFU7m"},
-	{"ecac89cad93923c02321", "EJDM8drfXA6uyA"},
-	{"10c8511e", "Rt5zm"},
-	{"00000000000000000000", "1111111111"},
-}
+		// Hex inputs.
+		{hexToBytes("61"), "2g"},
+		{hexToBytes("626262"), "a3gV"},
+		{hexToBytes("636363"), "aPEr"},
+		{hexToBytes("73696d706c792061206c6f6e6720737472696e67"), "2cFupjhnEsSn59qHXstmK2ffpLv2"},
+		{hexToBytes("00eb15231dfceb60925886b67d065299925915aeb172c06647"), "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"},
+		{hexToBytes("516b6fcd0f"), "ABnLTmg"},
+		{hexToBytes("bf4f89001e670274dd"), "3SEo3LWLoPntC"},
+		{hexToBytes("572e4794"), "3EFU7m"},
+		{hexToBytes("ecac89cad93923c02321"), "EJDM8drfXA6uyA"},
+		{hexToBytes("10c8511e"), "Rt5zm"},
+		{hexToBytes("00000000000000000000"), "1111111111"},
+	}
 
-func TestBase58(t *testing.T) {
-	// Encode tests
-	for x, test := range stringTests {
-		tmp := []byte(test.in)
-		if res := Encode(tmp); res != test.out {
-			t.Errorf("Encode test #%d failed: got: %s want: %s",
-				x, res, test.out)
+	for i, test := range tests {
+		if res := Encode(test.decoded); res != test.encoded {
+			t.Errorf("Encode test #%d failed: got: %q, want: %q", i, res,
+				test.encoded)
+			continue
+		}
+
+		if res := Decode(test.encoded); !bytes.Equal(res, test.decoded) {
+			t.Errorf("Decode test #%d failed: got: %q, want: %q", i, res,
+				test.decoded)
 			continue
 		}
 	}
+}
 
-	// Decode tests
-	for x, test := range hexTests {
-		b, err := hex.DecodeString(test.in)
-		if err != nil {
-			t.Errorf("hex.DecodeString failed failed #%d: got: %s", x, test.in)
-			continue
-		}
-		if res := Decode(test.out); !bytes.Equal(res, b) {
-			t.Errorf("Decode test #%d failed: got: %q want: %q",
-				x, res, test.in)
-			continue
-		}
+// TestBase58DecodeInvalid ensures Decode produces an empty result when provided
+// with invalid base58 encodings.
+func TestBase58DecodeInvalid(t *testing.T) {
+	tests := []string{
+		"0", "O", "I", "l", "3mJr0", "O3yxU", "3sNI", "4kl8", "0OIl",
+		"!@#$%^&*()-_=+~`",
 	}
 
-	// Decode with invalid input
-	for x, test := range invalidStringTests {
-		if res := Decode(test.in); string(res) != test.out {
-			t.Errorf("Decode invalidString test #%d failed: got: %q want: %q",
-				x, res, test.out)
+	for i, test := range tests {
+		if res := Decode(test); !bytes.Equal(res, []byte("")) {
+			t.Errorf("Decode test #%d failed: got: %q, want: %q", i, res, test)
 			continue
 		}
 	}

--- a/base58check_test.go
+++ b/base58check_test.go
@@ -6,63 +6,66 @@
 package base58
 
 import (
+	"strings"
 	"testing"
 )
 
-var checkEncodingStringTests = []struct {
-	version byte
-	in      string
-	out     string
-}{
-	{20, "", "Axk2WA6L"},
-	{20, " ", "kxg5DGCa1"},
-	{20, "-", "kxhWqwoTY"},
-	{20, "0", "kxhrrcZDw"},
-	{20, "1", "kxhzgbzwe"},
-	{20, "-1", "4M2qnQVfVwu"},
-	{20, "11", "4M2smzp65NR"},
-	{20, "abc", "FmT72s9HXyp6"},
-	{20, "1234598760", "3UFLKR4oYrL1hSX1Eu2W3F"},
-	{20, "abcdefghijklmnopqrstuvwxyz", "2M5VSfthNqvveeGWTcKRgY4Rm258o4ZDKBZGkAQ799jp"},
-	{20, "00000000000000000000000000000000000000000000000000000000000000", "3cmTs9hNQGCVmurJUgS7UokKFYZCCJWvWfYRBCaox5hXDn3Giiy1u9AEKn7vLS8K87BcDr6Ckr4JYRnnaSMRDsB49i3eU"},
-}
-
+// TestBase58Check ensures CheckDecode and CheckEncode produces the expected
+// results for inputs with a given version as well as decoding errors.
 func TestBase58Check(t *testing.T) {
-	for x, test := range checkEncodingStringTests {
-		var ver [2]byte
-		ver[0] = test.version
-		ver[1] = 0
-		// test encoding
-		if res := CheckEncode([]byte(test.in), ver); res != test.out {
-			t.Errorf("CheckEncode test #%d failed: got %s, want: %s", x, res, test.out)
+	tests := []struct {
+		version [2]byte
+		decoded string
+		encoded string
+	}{
+		{[2]byte{20, 0}, "", "Axk2WA6L"},
+		{[2]byte{20, 0}, " ", "kxg5DGCa1"},
+		{[2]byte{20, 0}, "-", "kxhWqwoTY"},
+		{[2]byte{20, 0}, "0", "kxhrrcZDw"},
+		{[2]byte{20, 0}, "1", "kxhzgbzwe"},
+		{[2]byte{20, 0}, "-1", "4M2qnQVfVwu"},
+		{[2]byte{20, 0}, "11", "4M2smzp65NR"},
+		{[2]byte{20, 0}, "abc", "FmT72s9HXyp6"},
+		{[2]byte{20, 0}, "1234598760", "3UFLKR4oYrL1hSX1Eu2W3F"},
+		{[2]byte{20, 0}, "abcdefghijklmnopqrstuvwxyz", "2M5VSfthNqvveeGWTcKRgY4Rm258o4ZDKBZGkAQ799jp"},
+		{[2]byte{20, 0}, "00000000000000000000000000000000000000000000000000000000000000", "3cmTs9hNQGCVmurJUgS7UokKFYZCCJWvWfYRBCaox5hXDn3Giiy1u9AEKn7vLS8K87BcDr6Ckr4JYRnnaSMRDsB49i3eU"},
+	}
+
+	for i, test := range tests {
+		// Test encoding.
+		gotEncoded := CheckEncode([]byte(test.decoded), test.version)
+		if gotEncoded != test.encoded {
+			t.Errorf("CheckEncode test #%d failed: got %q, want: %q", i,
+				gotEncoded, test.encoded)
+			continue
 		}
 
-		// test decoding
-		res, version, err := CheckDecode(test.out)
+		// Test decoding.
+		gotDecoded, version, err := CheckDecode(test.encoded)
 		if err != nil {
-			t.Errorf("CheckDecode test #%d failed with err: %v", x, err)
-		} else if version != ver {
-			t.Errorf("CheckDecode test #%d failed: got version: %d want: %d", x, version, ver)
-		} else if string(res) != test.in {
-			t.Errorf("CheckDecode test #%d failed: got: %s want: %s", x, res, test.in)
+			t.Errorf("CheckDecode test #%d failed with err: %v", i, err)
+		} else if version != test.version {
+			t.Errorf("CheckDecode test #%d failed: got version: %x, want: %x",
+				i, version, test.version)
+		} else if string(gotDecoded) != test.decoded {
+			t.Errorf("CheckDecode test #%d failed: got: %q, want: %q", i,
+				gotDecoded, test.decoded)
 		}
 	}
 
-	// test the two decoding failure cases
-	// case 1: checksum error
+	// Test the two decoding failure cases:
+	// case 1: Checksum error.
 	_, _, err := CheckDecode("Axk2WA6M")
 	if err != ErrChecksum {
 		t.Error("Checkdecode test failed, expected ErrChecksum")
 	}
-	// case 2: invalid formats (string lengths below 5 mean the version byte and/or the checksum
-	// bytes are missing).
-	testString := ""
-	for len := 0; len < 4; len++ {
-		// make a string of length `len`
+	// case 2: invalid formats (string lengths below 6 mean the version byte
+	// and/or the checksum bytes are missing).
+	for size := 0; size < 6; size++ {
+		testString := strings.Repeat("1", size)
 		_, _, err = CheckDecode(testString)
 		if err != ErrInvalidFormat {
 			t.Error("Checkdecode test failed, expected ErrInvalidFormat")
 		}
 	}
-
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/decred/dcrd/crypto/blake256"
 )
 
+// BenchmarkBase58Encode benchmarks how long it takes to perform a base58 encode
+// on a typical input.
 func BenchmarkBase58Encode(b *testing.B) {
 	var input [20]byte
 	hash := blake256.Sum256(input[:])
@@ -23,6 +25,8 @@ func BenchmarkBase58Encode(b *testing.B) {
 	}
 }
 
+// BenchmarkBase58Decode benchmarks how long it takes to perform a base58 decode
+// on a typical input.
 func BenchmarkBase58Decode(b *testing.B) {
 	var input [20]byte
 	hash := blake256.Sum256(input[:])

--- a/bench_test.go
+++ b/bench_test.go
@@ -38,6 +38,7 @@ func BenchmarkBase58Decode(b *testing.B) {
 var (
 	noElideResult  []byte
 	noElideVersion [2]byte
+	noElideEncoded string
 )
 
 // BenchmarkCheckDecode benchmarks how long it takes to perform a base58 check
@@ -54,5 +55,18 @@ func BenchmarkCheckDecode(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// BenchmarkCheckEncode benchmarks how long it takes to perform a base58 check
+// encode on a typical input.
+func BenchmarkCheckEncode(b *testing.B) {
+	var input [20]byte
+	version := [2]byte{0x07, 0x3f}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		noElideEncoded = CheckEncode(input[:], version)
 	}
 }


### PR DESCRIPTION
**This is rebased on PR #14**.

This updates the tests to be more consistent with the rest of the code base, adds missing comments, and makes the `CheckDecode` invalid format test do what the comment intended it to do.
