### PR TITLE
Decode bytes versus runes.

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -22,7 +22,7 @@ func Decode(input string) []byte {
 	// determine the final output size in favor of just keeping track while
 	// iterating.
 	var index int
-	for _, r := range input {
+	for _, r := range []byte(input) {
 		// Invalid base58 character.
 		val := uint32(b58[r])
 		if val == 255 {
@@ -44,7 +44,7 @@ func Decode(input string) []byte {
 
 	// Account for the leading zeros in the input.  They are appended since the
 	// encoding is happening in reverse order.
-	for _, r := range input {
+	for _, r := range []byte(input) {
 		if r != alphabetIdx0 {
 			break
 		}


### PR DESCRIPTION
This modifies the decode logic to work with bytes instead of runes to ensure proper behavior with all types of malformed strings.

The following is a before and after comparison of typical decoding.  As can be seen, this has no effect on the allocations and no tangible effect on performance.

```
benchmark               old ns/op    new ns/op    delta
--------------------------------------------------------
BenchmarkBase58Decode   805          805          +0.00%
BenchmarkCheckDecode    1250         1229         -1.68%

benchmark               old allocs   new allocs   delta
--------------------------------------------------------
BenchmarkBase58Decode   1            1            +0.00%
BenchmarkCheckDecode    1            1            +0.00%

benchmark               old bytes    new bytes    delta
--------------------------------------------------------
BenchmarkBase58Decode   48           48           +0.00%
BenchmarkCheckDecode    48           48           +0.00%
```