### PR TITLE
Require go1.13+.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/decred/base58
 
-go 1.11
+go 1.13
 
 require github.com/decred/dcrd/crypto/blake256 v1.0.0


### PR DESCRIPTION
This updates the module to require `go1.13` since it makes use of shifts on integers (technically signed shifts although they are only ever used with positive values) and the upcoming version of `go1.18` along with the latest version of `gopls` complains about not requiring `go1.13`.