### PR TITLE
build: Update build tags to pref go1.17+ syntax.

### DIFF
--- a/genalphabet.go
+++ b/genalphabet.go
@@ -1,9 +1,10 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 


### PR DESCRIPTION
This updates the build tags used to generate the alphabet to the preferred syntax as of go 1.17+.