### PR TITLE
multi: Build updates for Go 1.20. 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # 3.5.2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2"
       - name: Test
         env:
           GO111MODULE: "on"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: ["1.19", "1.20"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 #v4.0.0
@@ -17,7 +17,5 @@ jobs:
       - name: Install Linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2"
       - name: Test
-        env:
-          GO111MODULE: "on"
         run: |
           sh ./run_tests.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,11 +9,11 @@ jobs:
         go: [1.16, 1.17]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 #v4.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # 3.5.2
       - name: Install Linters
         run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2"
       - name: Test

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@
 Package base58 provides an API for working with modified base58 and Base58Check
 encodings.
 
-Modified Base58 Encoding
+# Modified Base58 Encoding
 
 Standard base58 encoding is similar to standard base64 encoding except, as the
 name implies, it uses a 58 character alphabet which results in an alphanumeric
@@ -18,7 +18,7 @@ The modified base58 alphabet used by Decred, and hence this package,
 omits the 0, O, I, and l characters that look the same in many fonts
 and are therefore hard to humans to distinguish.
 
-Base58Check Encoding Scheme
+# Base58Check Encoding Scheme
 
 The Base58Check encoding scheme is primarily used for Decred addresses at the
 time of this writing, however it can be used to generically encode arbitrary


### PR DESCRIPTION
This consists of several commits to update the CI for Go 1.20. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 #v4.0.0
  - actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
- build: Update golangci-lint to v1.52.2.
- build: Test against Go 1.20 and Go 1.19.
