### PR TITLE
Use latest dep and support module graph prune.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/decred/base58
 
-go 1.13
+go 1.17
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.0
+require github.com/decred/dcrd/crypto/blake256 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=


### PR DESCRIPTION
**This is rebased on #24**.

Use latest dep and support module graph prune.

This bumps the go directive for the module to 1.17 which will allow the new module graph pruning and lazy loading capabilities introduced in Go 1.17 to be used once an updated module is released.

It also updates to the latest version of the `blake256`.
