### PR TITLE
multi: Build updates for Go 1.25.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.24", "1.25"]
     steps:
       - name: Check out source
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2"
+        run: "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0"
       - name: Test
         run: |
           sh ./run_tests.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,12 +8,12 @@ jobs:
       matrix:
         go: ["1.19", "1.20"]
     steps:
+      - name: Check out source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 #v4.0.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ matrix.go }}
-      - name: Check out source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # 3.5.2
       - name: Install Linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2"
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+version: "2"
+run:
+  timeout: 10m
+linters:
+  default: none
+  enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - dupword
+    - durationcheck
+    - errcheck
+    - errorlint
+    - govet
+    - grouper
+    - ineffassign
+    - misspell
+    - nilerr
+    - nosprintfhostport
+    - paralleltest
+    - reassign
+    - rowserrcheck
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unused
+    - usetesting
+  settings:
+    staticcheck:
+      checks:
+          - S1*
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/base58_test.go
+++ b/base58_test.go
@@ -24,6 +24,8 @@ func hexToBytes(origHex string) []byte {
 // TestBase58Coding ensures [Decode] and [Encode] produce the expected results
 // for both strings and raw byte data converted from hex.
 func TestBase58Coding(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		decoded []byte
 		encoded string
@@ -73,6 +75,8 @@ func TestBase58Coding(t *testing.T) {
 // TestBase58DecodeInvalid ensures [Decode] produces an empty result when
 // provided with invalid base58 encodings.
 func TestBase58DecodeInvalid(t *testing.T) {
+	t.Parallel()
+
 	tests := []string{
 		"0", "O", "I", "l", "3mJr0", "O3yxU", "3sNI", "4kl8", "0OIl",
 		"!@#$%^&*()-_=+~`",

--- a/base58check_test.go
+++ b/base58check_test.go
@@ -14,6 +14,8 @@ import (
 // TestBase58Check ensures [CheckDecode] and [CheckEncode] produce the expected
 // results for inputs with a given version as well as decoding errors.
 func TestBase58Check(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		version [2]byte
 		decoded string

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,30 +2,12 @@
 
 set -ex
 
-# The script does automatic checking on a Go package and its sub-packages, including:
-# 1. race detector (http://blog.golang.org/race-detector)
-# 2. gofmt         (http://golang.org/cmd/gofmt/)
-# 3. golint        (https://github.com/golang/lint)
-# 4. go vet        (http://golang.org/cmd/vet)
-# 5. gosimple      (https://github.com/dominikh/go-simple)
-# 6. unconvert     (https://github.com/mdempsky/unconvert)
-# 7. ineffassign   (https://github.com/gordonklaus/ineffassign)
-# 8. misspell      (https://github.com/client9/misspell)
-# 9. deadcode      (https://github.com/remyoudompheng/go-misc/tree/master/deadcode)
+# This script runs the tests for all packages in the repository and then uses
+# golangci-lint (github.com/golangci/golangci-lint) to run all linters defined
+# by the configuration in .golangci.yml.
 
 # run tests
 env GORACE="halt_on_error=1" go test -race ./...
 
-# golangci-lint (github.com/golangci/golangci-lint) is used to run each each
-# static checker.
-
-# check linters
-golangci-lint run --disable-all --deadline=10m \
-  --enable=gofmt \
-  --enable=revive \
-  --enable=vet \
-  --enable=gosimple \
-  --enable=unconvert \
-  --enable=ineffassign \
-  --enable=misspell \
-  --enable=deadcode
+# run linters
+golangci-lint run


### PR DESCRIPTION
This consists of several commits to update the CI for Go 1.25. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- Run tests in parallel.
- build: Update to latest action versions.
  - actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
  -  actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
- build: Update golangci-lint to v2.0.4.
  - Adds several new linters as part of v2 upgrade
- build: Test against Go 1.24 and Go 1.25.