### PR TITLE
Optimize decode for ~27-75% better performance.

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -1,9 +1,13 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package base58
+
+import (
+	"math/bits"
+)
 
 //go:generate go run genalphabet.go
 
@@ -13,45 +17,92 @@ func Decode(input string) []byte {
 		return []byte("")
 	}
 
-	// The max possible output size is when a base58 encoding consists of
-	// nothing but the alphabet character at index 0 which would result in the
-	// same number of bytes as the number of input chars.
-	output := make([]byte, len(input))
+	// Determine the maximum possible output size.
+	//
+	// Since the conversion is from base58 to base256, the max possible number
+	// of bytes of output per input byte, excluding the leading zeros, is
+	// log_256(58).  Therefore, the max total output size is the number of
+	// leading zero bytes plus ceil(inputSizeMinusLeadingZeros * log_256(58)).
+	//
+	// Note that log_256(58) ~= 0.7322 < 47/64 which is within 0.3% of the true
+	// value and efficient to compute as it only involves division by a power of
+	// 2 and thus serves as a good approximation.  So, the calculation below is
+	// the integer division equivalent of nlz + ceil(len(input[nlz:]) * 47/64).
+	//
+	// Finally, in order to avoid additional conditional branches in the
+	// conversion from uint32s to bytes, the max output size is rounded up to
+	// the next multiple of 4.
+	var nlz int
+	for i := 0; i < len(input) && input[i] == alphabetIdx0; i++ {
+		nlz++
+	}
+	maxOutputSizeNoLZ := (len(input[nlz:])*47 + 63) / 64
+	maxOutputSize := nlz + maxOutputSizeNoLZ
+	maxOutputSize = ((maxOutputSize + 3) / 4) * 4
+	output := make([]byte, maxOutputSize)
 
-	// Encode to base256 in reverse order to avoid extra calculations to
-	// determine the final output size in favor of just keeping track while
-	// iterating.
-	var index int
-	for _, r := range []byte(input) {
+	// The algorithm below performs the calculations with uint32s for better
+	// performance and the total number of uint32s is ceil(maxOutputSizeNoLZ /
+	// 4).  Note that the leading zeros are skipped here, so the calculation is
+	// based on the max output size excluding them.
+	//
+	// In order to avoid an additional heap allocation for the vast majority of
+	// typical cases, use an array on the stack for inputs of up to 120 chars
+	// (plus any leading zeros) and fall back to a heap alloc for larger inputs.
+	// Note that 120 input chars, excluding leading zeros, equates to a max
+	// output size of 92 when applying the same calculations as above.
+	//
+	// This value was chosen because it provides a good balance between alloc
+	// size, speed, and the max chars in the vast majority of inputs decoded in
+	// the most common use cases.
+	const maxOut32StackAlloc = 92 / 4
+	maxOut32Size := (maxOutputSizeNoLZ + 3) / 4
+	var out32 []uint32
+	if maxOut32Size <= maxOut32StackAlloc {
+		var out32Arr [maxOut32StackAlloc]uint32
+		out32 = out32Arr[:maxOut32Size]
+	} else {
+		out32 = make([]uint32, maxOut32Size)
+	}
+
+	// Decode to base256 in reverse order to reduce the total number of overall
+	// calculations.
+	var out32Idx int
+	for _, r := range []byte(input[nlz:]) {
 		// Invalid base58 character.
-		val := uint32(b58[r])
+		val := uint64(b58[r])
 		if val == 255 {
 			return []byte("")
 		}
 
-		// Multiply each byte in the output by 58 and encode to base256 while
-		// propagating the carry.
-		for i, b := range output[:index] {
-			val += uint32(b) * 58
-			output[i] = byte(val)
-			val >>= 8
+		for i, ui32 := range out32[:out32Idx] {
+			val += uint64(ui32) * 58
+			out32[i] = uint32(val) // nolint:gosec
+			val >>= 32
 		}
-		for ; val > 0; val >>= 8 {
-			output[index] = byte(val)
-			index++
+		if val > 0 {
+			out32[out32Idx] = uint32(val) // nolint:gosec
+			out32Idx++
 		}
 	}
 
-	// Account for the leading zeros in the input.  They are appended since the
-	// encoding is happening in reverse order.
-	for _, r := range []byte(input) {
-		if r != alphabetIdx0 {
-			break
-		}
-
-		output[index] = 0
-		index++
+	// Convert uint32 words to bytes.
+	var index int
+	for _, ui32 := range out32[:out32Idx] {
+		output[index] = byte(ui32)
+		output[index+1] = byte(ui32 >> 8)
+		output[index+2] = byte(ui32 >> 16)
+		output[index+3] = byte(ui32 >> 24)
+		index += 4
 	}
+
+	// Adjust the output index to the position of the most significant byte and
+	// to account for the leading zeros in the input.  They come last since the
+	// decoding is happening in reverse order.
+	if out32Idx > 0 {
+		index -= bits.LeadingZeros32(out32[out32Idx-1]) / 8
+	}
+	index += nlz
 
 	// Truncate the output buffer to the actual number of decoded bytes and
 	// reverse it since it was calculated in reverse order.

--- a/base58_test.go
+++ b/base58_test.go
@@ -8,6 +8,7 @@ package base58
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -123,4 +124,36 @@ func TestBase58DecodeInvalid(t *testing.T) {
 			continue
 		}
 	}
+}
+
+// FuzzDecode provides a fuzzing target for [Decode].
+func FuzzDecode(f *testing.F) {
+	f.Add("")
+	for i := 0; i < 256; i++ {
+		f.Add(string([]byte{byte(i)}))
+	}
+	f.Add("10")
+	f.Add("11")
+	f.Add("210")
+	f.Add("211")
+	f.Add("1110")
+	f.Add("1111")
+	f.Add("71111")
+	f.Add("11111111")
+	f.Add("21111111")
+	f.Add("211111111111")
+	f.Add("1111111111111111")
+	f.Add(strings.Repeat("1", 87))
+	f.Add("2" + strings.Repeat("1", 127))
+	f.Add("2111111111111111111111111")
+	f.Add("11111111111111111111111111111111")
+	f.Add("2111111111111111111111111111111111111111")
+	f.Add("2" + strings.Repeat("1", 156))
+	f.Add("7" + strings.Repeat("1", 169))
+	f.Add("1117" + strings.Repeat("1", 344))
+	f.Add("X" + strings.Repeat("1", 693))
+	f.Add(strings.Repeat("1", 128))
+	f.Fuzz(func(t *testing.T, input string) {
+		Decode(input)
+	})
 }

--- a/base58_test.go
+++ b/base58_test.go
@@ -41,20 +41,55 @@ func TestBase58Coding(t *testing.T) {
 		{[]byte("abc"), "ZiCa"},
 		{[]byte("1234598760"), "3mJr7AoUXx2Wqd"},
 		{[]byte("abcdefghijklmnopqrstuvwxyz"), "3yxU3u1igY8WkgtjK92fbJQCd4BZiiT1v25f"},
-		{[]byte("00000000000000000000000000000000000000000000000000000000000000"), "3sN2THZeE9Eh9eYrwkvZqNstbHGvrxSAM7gXUXvyFQP8XvQLUqNCS27icwUeDT7ckHm4FUHM2mTVh1vbLmk7y"},
+		{
+			[]byte("00000000000000000000000000000000000000000000000000000000000000"),
+			"3sN2THZeE9Eh9eYrwkvZqNstbHGvrxSAM7gXUXvyFQP8XvQLUqNCS27icwUeDT7ckHm4FUHM2mTVh1vbLmk7y",
+		},
+		{
+			bytes.Repeat([]byte("0"), 200),
+			"KdhzWGVLoe2Z7u7v8kU6dSjNhdK8HNqQbVswpifqRXqmC5a6eFUoTLjhu41kZtTc" +
+				"6Am7Dzp8FcpoMubGyeiAinFQzGavztm4nnAm65i72UDh3FsTLbkoJf5oVNvx" +
+				"VALvaqWzugRNxNEs75g75wyubjXGhFxk4etvhvfdxu7JiwhXk1cWwnLUPjMY" +
+				"DGMFi2BEd8qMkB2wE8ACUHwdk3hHYuwaYKbEpFzjVQZwsRQo8JoFYozwdrFB" +
+				"Ys1F5NW6AtTVKMefQ6MGpGCxcjsWw",
+		},
 
 		// Hex inputs.
 		{hexToBytes("61"), "2g"},
 		{hexToBytes("626262"), "a3gV"},
 		{hexToBytes("636363"), "aPEr"},
-		{hexToBytes("73696d706c792061206c6f6e6720737472696e67"), "2cFupjhnEsSn59qHXstmK2ffpLv2"},
-		{hexToBytes("00eb15231dfceb60925886b67d065299925915aeb172c06647"), "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"},
+		{
+			hexToBytes("73696d706c792061206c6f6e6720737472696e67"),
+			"2cFupjhnEsSn59qHXstmK2ffpLv2",
+		},
+		{
+			hexToBytes("00eb15231dfceb60925886b67d065299925915aeb172c06647"),
+			"1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L",
+		},
 		{hexToBytes("516b6fcd0f"), "ABnLTmg"},
 		{hexToBytes("bf4f89001e670274dd"), "3SEo3LWLoPntC"},
 		{hexToBytes("572e4794"), "3EFU7m"},
 		{hexToBytes("ecac89cad93923c02321"), "EJDM8drfXA6uyA"},
 		{hexToBytes("10c8511e"), "Rt5zm"},
+		{
+			hexToBytes("426018fe18ee72f798faacf8ed1efcd786577ad07f33124120fc9" +
+				"537ba97fbe5c5dbd46b66ebd88d11b650b06662914b12aa80ca90110d9b5" +
+				"7337c45ee224cf6ba1d9a3aaf92a232dfebc251c78753fe9f9215bfe7c43" +
+				"744"),
+			"XyJrepxxsECdexAWReSjewTiyL6Ekj5W22bSqxjZfCUsns6QpSHD8bKw33z1YrDZ" +
+				"yD3S1H4iQawvXMTfxfjm8SdyCo8W989jvzEj4qUdZwzjgkMaz7Jx2fCw",
+		},
+		{hexToBytes("0000000002060730"), "111141111"},
+		{hexToBytes("00"), "1"},
+		{hexToBytes("0000"), "11"},
+		{hexToBytes("000000"), "111"},
+		{hexToBytes("00000000"), "1111"},
+		{hexToBytes("0000000000"), "11111"},
 		{hexToBytes("00000000000000000000"), "1111111111"},
+		{hexToBytes("0000000000000000000000"), "11111111111"},
+		{hexToBytes("000000000000000000000000"), "111111111111"},
+		{hexToBytes("00000000000000000000000000"), "1111111111111"},
+		{hexToBytes("0000000000000000000000000000"), "11111111111111"},
 	}
 
 	for i, test := range tests {
@@ -65,8 +100,8 @@ func TestBase58Coding(t *testing.T) {
 		}
 
 		if res := Decode(test.encoded); !bytes.Equal(res, test.decoded) {
-			t.Errorf("Decode test #%d failed: got: %q, want: %q", i, res,
-				test.decoded)
+			t.Errorf("Decode test #%d failed: got: %q (%#[2]x), want: %q "+
+				"(%#[3]x)", i, res, test.decoded)
 			continue
 		}
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,41 +1,76 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package base58
 
 import (
+	"bytes"
 	"testing"
-
-	"github.com/decred/dcrd/crypto/blake256"
 )
 
-// BenchmarkBase58Encode benchmarks how long it takes to perform a base58 encode
-// on a typical input.
-func BenchmarkBase58Encode(b *testing.B) {
-	var input [20]byte
-	hash := blake256.Sum256(input[:])
-	data := hash[:]
+// base58BenchTest describes tests that are used for the various base58
+// benchmarks.  It is defined separately so the same tests can easily be used in
+// comparison benchmarks.
+type base58BenchTest struct {
+	name    string // benchmark description
+	encoded string // encoded value
+	data    []byte // decoded bytes
+}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Encode(data)
+// makeBase58Benches returns a slice of tests that consist of an encoded base58
+// string and its associated decoded data for use in the base58 benchmarks.
+func makeBase58Benches() []base58BenchTest {
+	addrHash := hexToBytes("2789d58cfa0957d206f025c2af056fc8a77cebb0")
+	wif := "PmQdMn8xafwaQouk8ngs1CccRCB1ZmsqQxBaxNR4vhQi5a5QB5716"
+	extKey := "dpubZ9169KDAEUnyoBhjjmT2VaEodr6pUTDoqCEAeqgbfr2JfkB88BbK77jbTY" +
+		"bcYXb2FVz7DKBdW4P618yd51MwF8DjKVopSbS7Lkgi6bowX5w"
+	fiftyZeros := bytes.Repeat([]byte{0x00}, 50)
+	large := hexToBytes("0102030405060708090a0b0c0d0e0f101112131415161718191a" +
+		"1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c" +
+		"3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e" +
+		"5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f80" +
+		"8182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2" +
+		"a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4" +
+		"c5c6c7c8")
+
+	return []base58BenchTest{
+		{name: "20_bytes_addrhash", encoded: Encode(addrHash), data: addrHash},
+		{name: "53_chars_wif", encoded: wif, data: Decode(wif)},
+		{name: "111_chars_extkey", encoded: extKey, data: Decode(extKey)},
+		{name: "50_zeros", encoded: Encode(fiftyZeros), data: fiftyZeros},
+		{name: "200_bytes_large", encoded: Encode(large), data: large},
+	}
+}
+
+// BenchmarkBase58Encode benchmarks how long it takes to perform a base58 encode
+// on typical inputs.
+func BenchmarkBase58Encode(b *testing.B) {
+	benches := makeBase58Benches()
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				Encode(bench.data)
+			}
+		})
 	}
 }
 
 // BenchmarkBase58Decode benchmarks how long it takes to perform a base58 decode
-// on a typical input.
+// on typical inputs.
 func BenchmarkBase58Decode(b *testing.B) {
-	var input [20]byte
-	hash := blake256.Sum256(input[:])
-	encoded := Encode(hash[:])
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Decode(encoded)
+	benches := makeBase58Benches()
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				Decode(bench.encoded)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**This is rebased on #28**.

This optimizes the decode function to significantly improve its performance.

It accomplishes this by making the following overall changes:

- uses uint32 words to reduce the total number of multiplications that need to be done
- changes to a more efficient total size approximation which reduces the overall internal buffer sizes
- employs a stack allocated array for the internal array when working with typical sizes
- skips all leading zeros

Note that there is in an additional heap allocation for larger inputs as compared to the existing code, but the overall perf gains on such large inputs is even better than on the more typical smaller inputs due to fewer overall calculations which more than makes up for it as can be seen in the benchmarks.

Finally, in an effort to help ensure correctness, the new code was fuzz tested for 24 hours on 16 cores for a total effective fuzz time of 384 hours with no issues found.

```
name                             old time/op   new time/op   delta
--------------------------------------------------------------------
Base58Decode/20_bytes_addrhash    240ns ± 2%    133ns ± 1%   -44.34%
Base58Decode/53_chars_wif         798ns ± 2%    299ns ± 1%   -62.51%
Base58Decode/111_chars_extkey    3.54µs ± 1%   1.01µs ± 2%   -71.51%
Base58Decode/50_zeros             128ns ± 1%     69ns ± 1%   -46.14%
Base58Decode/200_bytes_large     20.0µs ± 1%    5.1µs ± 0%   -74.29%
CheckDecode                       677ns ± 1%    493ns ± 0%   -27.24%

name                             old allocs/op new allocs/op  delta
----------------------------------------------------------------------
Base58Decode/20_bytes_addrhash   1.00 ± 0%     1.00 ± 0%      ~
Base58Decode/53_chars_wif        1.00 ± 0%     1.00 ± 0%      ~
Base58Decode/111_chars_extkey    1.00 ± 0%     1.00 ± 0%      ~
Base58Decode/50_zeros            1.00 ± 0%     1.00 ± 0%      ~
Base58Decode/200_bytes_large     1.00 ± 0%     2.00 ± 0%      +100.00%
CheckDecode                      1.00 ± 0%     1.00 ± 0%      ~
```